### PR TITLE
Add a rewrite for varargs

### DIFF
--- a/input/src/main/scala/fix/Varargs.scala
+++ b/input/src/main/scala/fix/Varargs.scala
@@ -1,0 +1,8 @@
+/*
+rule = Varargs
+*/
+package fix
+
+class Varargs {
+  def foo(xs: scala.collection.Seq[String]) = List(xs: _*)
+}

--- a/output/src/main/scala/fix/Varargs.scala
+++ b/output/src/main/scala/fix/Varargs.scala
@@ -1,0 +1,5 @@
+package fix
+
+class Varargs {
+  def foo(xs: scala.collection.Seq[String]) = List(xs.toSeq: _*)
+}

--- a/rewrites/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rewrites/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,1 +1,2 @@
 fix.Scala_2_13
+fix.Varargs

--- a/rewrites/src/main/scala/fix/Varargs.scala
+++ b/rewrites/src/main/scala/fix/Varargs.scala
@@ -1,0 +1,25 @@
+package fix
+
+import scalafix.v1._
+import scala.meta._
+
+object Varargs {
+  val scSeq = new SignatureMatcher(SymbolMatcher.exact("scala/collection/Seq#"))
+}
+
+final class Varargs extends SemanticRule("Varargs") {
+  import Varargs._
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    doc.tree.collect {
+      case Term.Repeated(scSeq(expr)) => Patch.addRight(expr, ".toSeq")
+    }.asPatch
+  }
+}
+
+final class SignatureMatcher(symbolMatcher: SymbolMatcher) {
+  def unapply(tree: Tree)(implicit sdoc: SemanticDocument): Option[Tree] =
+    tree.symbol.info.map(_.signature).collect {
+      case ValueSignature(TypeRef(_, symbolMatcher(_), _)) => tree
+    }
+}


### PR DESCRIPTION
I think we can rewrite any code that tries to `: _*` a `scala.collection.Seq` to call `toSeq` before doing so.  Also, if the original code is 2.12 code, that it should also do it for `scala.Seq`.

It won't make the resulting code efficient (it would be more efficient for the seq to already be immutable), but it would make the code compile.

We should probably do it in Lukas' https://github.com/lrytz/scala-rewrites/tree/seq-to-seq branch and then talk about integrating that branch into master.