### PR TITLE
ExplicitNonNullaryApply incorrectly rewrite Eta `meth _` to `meth() _`

### DIFF
--- a/input/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
+++ b/input/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
@@ -73,4 +73,6 @@ class ExplicitNonNullaryApply {
   def def_enna_enna_id_m_ta    = enna.enna.id[String]("")
   def def_enna_enna_id_m_in    = enna.enna id ""
   def def_enna_enna_id_m_in_ta = enna.enna id[String] ""
+
+  def eta = meth _
 }

--- a/output/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
+++ b/output/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
@@ -70,4 +70,6 @@ class ExplicitNonNullaryApply {
   def def_enna_enna_id_m_ta    = enna.enna.id[String]("")
   def def_enna_enna_id_m_in    = enna.enna id ""
   def def_enna_enna_id_m_in_ta = enna.enna id[String] ""
+
+  def eta = meth _
 }

--- a/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
+++ b/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
@@ -40,6 +40,7 @@ final class ExplicitNonNullaryApply(global: LazyValue[ScalafixGlobal])
         if noArgs
         if name.isReference
         if !name.parent.exists(_.is[Term.ApplyInfix])
+        if !tree.parent.exists(_.is[Term.Eta])
         info <- name.symbol.info
         if !power.isJavaDefined(name) // !info.isJava
         if cond(info.signature) { case MethodSignature(_, List(Nil), _) => true }


### PR DESCRIPTION
Without the change in this PR, user must run `ExplicitNullaryEtaExpansion` rule before `ExplicitNonNullaryApply`