### PR TITLE
ExplicitNonNullaryApply also fix ApplyType

### DIFF
--- a/input/src/main/scala/fix/scala213/ExplicitNonNullaryApplyApplyType.scala
+++ b/input/src/main/scala/fix/scala213/ExplicitNonNullaryApplyApplyType.scala
@@ -1,0 +1,29 @@
+/*
+rule = fix.scala213.ExplicitNonNullaryApply
+*/
+package fix.scala213
+
+class ExplicitNonNullaryApplyApplyType {
+
+  object Props {
+    def apply[A]() = ???
+  }
+
+  object Props2 {
+    def apply[A, B]() = ???
+  }
+
+  object Nullary {
+    def apply[A] = ???
+    def foo() = ???
+  }
+
+  Props.apply[Int] // fix
+  Props[Int] // fix
+  Props[Int]() // keep
+
+  Props2.apply[Int, String] // fix
+  Props2[Int, String] // fix
+
+  Nullary[Int] // keep
+}

--- a/output/src/main/scala/fix/scala213/ExplicitNonNullaryApplyApplyType.scala
+++ b/output/src/main/scala/fix/scala213/ExplicitNonNullaryApplyApplyType.scala
@@ -1,0 +1,26 @@
+package fix.scala213
+
+class ExplicitNonNullaryApplyApplyType {
+
+  object Props {
+    def apply[A]() = ???
+  }
+
+  object Props2 {
+    def apply[A, B]() = ???
+  }
+
+  object Nullary {
+    def apply[A] = ???
+    def foo() = ???
+  }
+
+  Props.apply[Int]() // fix
+  Props[Int]() // fix
+  Props[Int]() // keep
+
+  Props2.apply[Int, String]() // fix
+  Props2[Int, String]() // fix
+
+  Nullary[Int] // keep
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.14")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.15")

--- a/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
+++ b/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
@@ -45,6 +45,13 @@ final class ExplicitNonNullaryApply(global: LazyValue[ScalafixGlobal])
         if !power.isJavaDefined(name) // !info.isJava
         if cond(info.signature) {
           case MethodSignature(_, List(Nil, _*), _) => true
+          case ClassSignature(_, _, _, decls) if tree.isInstanceOf[Term.ApplyType] =>
+            decls.exists { decl =>
+              decl.displayName == "apply" &&
+                cond(decl.signature) {
+                  case MethodSignature(_, List(Nil, _*), _) => true
+                }
+            }
         }
       } yield Patch.addRight(if (noTypeArgs) name else tree, "()")
     }.asPatch


### PR DESCRIPTION
Given:
```
object Props {
  def apply[A]() = ???
}
```
Then `Props[Int]` is rewrite to `Props[Int]()`