### PR TITLE
ExplicitNonNullaryApply: workaround for scalameta/scalameta#1083

### DIFF
--- a/input/src/main/scala/fix/scala213/ExplicitNonNullaryApplyInfix.scala
+++ b/input/src/main/scala/fix/scala213/ExplicitNonNullaryApplyInfix.scala
@@ -19,4 +19,6 @@ trait ExplicitNonNullaryApplyInfixSpec extends Matchers {
   lhs() shouldBe arg
   lhs shouldBe arg()
   lhs() shouldBe arg()
+
+  lhs shouldBe (arg)
 }

--- a/output/src/main/scala/fix/scala213/ExplicitNonNullaryApplyInfix.scala
+++ b/output/src/main/scala/fix/scala213/ExplicitNonNullaryApplyInfix.scala
@@ -16,4 +16,6 @@ trait ExplicitNonNullaryApplyInfixSpec extends Matchers {
   lhs() shouldBe arg()
   lhs() shouldBe arg()
   lhs() shouldBe arg()
+
+  lhs() shouldBe (arg())
 }

--- a/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
+++ b/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
@@ -43,7 +43,7 @@ final class ExplicitNonNullaryApply(global: LazyValue[ScalafixGlobal])
           case Some(Term.ApplyInfix(_, `name`, _, _)) => true
         }
         if !tree.parent.exists(_.is[Term.Eta])
-        info <- name.symbol.info
+        info <- Workaround1104.symbol(name).info
         if !power.isJavaDefined(name) // !info.isJava
         if cond(info.signature) {
           case MethodSignature(_, List(Nil, _*), _) => true
@@ -56,7 +56,10 @@ final class ExplicitNonNullaryApply(global: LazyValue[ScalafixGlobal])
             }
         }
       } yield {
-        val right = Patch.addRight(if (noTypeArgs) name else tree, "()")
+        val tok =
+          if (noTypeArgs) Workaround1104.lastToken(name)
+          else tree.tokens.last
+        val right = Patch.addRight(tok, "()")
         name.parent match {
           // scalameta:trees don't have PostfixSelect like
           // scala.tools.nsc.ast.Trees.PostfixSelect

--- a/rewrites/src/main/scala/scalafix/v1/Workaround1104.scala
+++ b/rewrites/src/main/scala/scalafix/v1/Workaround1104.scala
@@ -1,0 +1,33 @@
+package scalafix.v1
+
+import scala.meta._
+
+/** workaround for:
+ * + https://github.com/scalameta/scalameta/issues/1083
+ * + https://github.com/scalacenter/scalafix/issues/1104 */
+object Workaround1104 {
+  /** Same as [[scalafix.v1.XtensionTreeScalafix.symbol]]
+   * but because of scalameta/scalameta#1083,
+   * sometimes `XtensionTreeScalafix.symbol` return `Symbol.None``
+   * In that case, we retry getting symbols at pos `name.pos`` */
+  def symbol(name: Name)(implicit doc: SemanticDocument): Symbol =
+    doc.internal.symbol(name) match {
+      case Symbol.None if needWorkaround(name) =>
+        doc.internal.symbols(name.pos)
+          .toStream.headOption // Discard multi symbols
+          .getOrElse(Symbol.None)
+      case sym => sym
+    }
+
+  def needWorkaround(name: Name): Boolean = {
+    val s = name.syntax
+    s.startsWith("(") && s.endsWith(")") && s != name.value
+  }
+
+  /** @return if the token `name` instead of `)` for `(name)` */
+  def lastToken(name: Name): Token = {
+    val tokens = name.tokens
+    if (needWorkaround(name)) tokens(tokens.length - 2)
+    else tokens.last
+  }
+}


### PR DESCRIPTION
and scalacenter/scalafix#1104

Given
```scala
trait Test {
  def shouldBe(r: Any) = ???
  def arg() = ""
  this shouldBe (arg)
}
```

Without changes in this commit then `this shouldBe (arg)`
+ will not be rewritten if scalacenter/scalafix#1104 is not fixed
+ will be rewritten to invalid code `this shouldBe (arg)()` if scalacenter/scalafix#1104 is fixed but scalameta/scalameta#1083 is not fixed