### PR TITLE
specify ExplicitNonNullaryApply supported scala version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ sbt ~tests/test
 1. Add sbt-scalafix: `addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.17")`
 2. Add SemanticDB: `addCompilerPlugin(scalafixSemanticdb)`
 3. Configure Semantic DB: `scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")`
-4. Run the rule: `scalafix dependency:Scala213@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT`
-5. Run the rule on test sources: `Test/scalafix dependency:Scala213@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT`
+4. Run a rule you want: `scalafix dependency:RULE_NAME@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT`
+   - For example, you can run Varargs rule by: `scalafix dependency:fix.scala213.Varargs@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT` 
+5. Run the rule on test sources: `Test/scalafix dependency:RULE_NAME@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# CAUTIONS!
+Current released Scalafix supports ExplicitNonNullaryApply [ONLY in Scala 2.12](https://github.com/scala/scala-rewrites/issues/31). 
+Scalafix will support 2.13 and 2.11 with cross-building ExplicitNonNullaryApply rule against them.  
+
 # Scalafix Rewrites for Scala
 
 ## To develop the rule
@@ -10,7 +14,7 @@ sbt ~tests/test
 ## To run the rule
 
 0. Publish the rule: `publishLocal`
-1. Add sbt-scalafix: `addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")`
+1. Add sbt-scalafix: `addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.17")`
 2. Add SemanticDB: `addCompilerPlugin(scalafixSemanticdb)`
 3. Configure Semantic DB: `scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")`
 4. Run the rule: `scalafix dependency:Scala213@org.scala-lang:scala-rewrites:0.1.0-SNAPSHOT`

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.15")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.17")


### PR DESCRIPTION
Hi, thank you for maintaining Scalafix rules to migrate easier.

I'd send this PR because:

- Current ExplicitNonNullaryApply rule supports only in Scala 2.12 as [rules compiled against 2.11 and 2.13](https://github.com/scalacenter/sbt-scalafix/pull/121) support is not released.
- [Scala 2.13.3 has been released](https://github.com/scala/scala/releases/tag/v2.13.3) with starting warn by default on mismatch of presence/absence of an empty parameter.

So Scala library maintainers start trying to use ExplicitNonNullaryApply in their Scala 2.13 projects. Since its migration rule Scala version support is not obvious, it would be pitfall for them.

IMHO it should be explicitly stated in README now, and can be removed right after Scalafix next version including cross-compiled rules support is released.

Your feedback is welcome.