### PR TITLE
Fix docs & sanity check Scala version coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,26 @@ inThisBuild(List(
   semanticdbEnabled := true,
   semanticdbOptions += "-P:semanticdb:synthetics:on", // make sure to add this
   semanticdbVersion := scalafixSemanticdb.revision,
+  scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value),
 ))
 ```
 
 Then run the desired rewrite(s) ([official docs][2]), in sbt:
 
 ```scala
-> scalafix dependency:fix.scala213.ExplicitNonNullaryApply@org.scala-lang:scala-rewrites:0.1.0
-> Test/scalafix dependency:fix.scala213.ExplicitNonNullaryApply@org.scala-lang:scala-rewrites:0.1.0
+> scalafixAll dependency:fix.scala213.ExplicitNonNullaryApply@org.scala-lang:scala-rewrites:0.1.1
 ```
 
 You can also add the following to your `build.sbt`:
 
 ```scala
-ThisBuild / scalafixDependencies += "org.scala-lang" %% "scala-rewrites" % "0.1.0"
+ThisBuild / scalafixDependencies += "org.scala-lang" %% "scala-rewrites" % "0.1.1"
 ```
 
 and then:
 
 ```scala
-> scalafix fix.scala213.ExplicitNonNullaryApply
-> Test/scalafix fix.scala213.ExplicitNonNullaryApply
+> scalafixAll fix.scala213.ExplicitNonNullaryApply
 ```
 
 [1]: https://scalacenter.github.io/scalafix/docs/users/installation.html


### PR DESCRIPTION
The new sbt-scalafix 0.9.18 release includes a
scalafixScalaBinaryVersion key that can be used to run, for instance,
the Scalafix for Scala 2.13 when running against sources compiled with
2.13.

Add those instructions to the README.  The nice thing is this new
version and setting can be used the releases scala-rewrites 0.1.0.

But also add a sanity check to ExplicitNonNullaryApply (continuing to
copy from Scalafix's ExplicitResultTypes), with some fixing tips.  This
is what it looks like on a test project:

    [error] (scalafixAll) scalafix.sbt.InvalidArgument: Scala version mismatch:
    (1) the target sources were compiled with Scala 2.13.2; (2) Scalafix is
    running on Scala 2.12.11. To fix make scalafixScalaBinaryVersion == 2.13.
    Try `ThisBuild / scalafixScalaBinaryVersion :=
    CrossVersion.binaryScalaVersion(scalaVersion.value)`.

Also switch the docs to scalafixAll, and prep for a 0.1.1 release.

Fixes #43