### PR TITLE
Drop needless source-recompile in Power

### DIFF
--- a/rewrites/src/main/scala/impl/Power.scala
+++ b/rewrites/src/main/scala/impl/Power.scala
@@ -2,7 +2,6 @@ package impl
 
 import scala.meta._
 import scala.meta.internal.pc.ScalafixGlobal
-import scala.meta.internal.proxy.GlobalProxy
 
 import scalafix.v1._
 import scalafix.internal.rule.CompilerException
@@ -11,28 +10,18 @@ import scalafix.internal.rule.CompilerException
 // From scalafix-rules/src/main/scala/scalafix/internal/rule/CompilerTypePrinter.scala#L55
 // in scalacenter/scalafix (at db93793c2a8f80d0e7bbcacef729dc5c2fa7ceb8).
 final class Power(g: ScalafixGlobal)(implicit doc: SemanticDocument) {
-  private lazy val unit = g.newCompilationUnit(doc.input.text, doc.input.syntax)
-
   def isJavaDefined(t: Tree): Boolean = try {
-    val meth = gsymbol(t)
-    isJavaDefined1(meth) || meth.overrides.exists(isJavaDefined1)
+    gsymbol(t).overrideChain.exists(sym => sym.isJavaDefined || sym.owner == g.definitions.AnyClass)
   } catch {
     case e: Throwable => throw CompilerException(e)
   }
 
-  private def isJavaDefined1(sym: g.Symbol) =
-    sym.isJavaDefined || sym.owner == g.definitions.AnyClass
-
   private def gsymbol(t: Tree): g.Symbol = {
-    GlobalProxy.typedTreeAt(g, unit.position(t.pos.start))
-
-    val sym = g
-      .inverseSemanticdbSymbols(t.symbol.value)
-      .find(t.symbol.value == g.semanticdbSymbol(_))
-      .getOrElse(g.NoSymbol)
-
-    if (sym.info.exists(g.definitions.NothingTpe == _))
-      sym.overrides.lastOption.getOrElse(sym)
-    else sym
+    val sSym = t.symbol
+    val gSymbols = g.inverseSemanticdbSymbols(sSym.value)
+    val gSym = gSymbols.find(gSym => g.semanticdbSymbol(gSym) == sSym.value).getOrElse(g.NoSymbol)
+    if (gSym.info.exists(g.definitions.NothingTpe == _))
+      gSym.overrides.lastOption.getOrElse(gSym)
+    else gSym
   }
 }

--- a/rewrites/src/main/scala/impl/Power.scala
+++ b/rewrites/src/main/scala/impl/Power.scala
@@ -19,9 +19,6 @@ final class Power(g: ScalafixGlobal)(implicit doc: SemanticDocument) {
   private def gsymbol(t: Tree): g.Symbol = {
     val sSym = t.symbol
     val gSymbols = g.inverseSemanticdbSymbols(sSym.value)
-    val gSym = gSymbols.find(gSym => g.semanticdbSymbol(gSym) == sSym.value).getOrElse(g.NoSymbol)
-    if (gSym.info.exists(g.definitions.NothingTpe == _))
-      gSym.overrides.lastOption.getOrElse(gSym)
-    else gSym
+    gSymbols.find(gSym => g.semanticdbSymbol(gSym) == sSym.value).getOrElse(g.NoSymbol)
   }
 }


### PR DESCRIPTION
It's unnecessary to recompile sources to gain symbol override
information, simply (IIUC) starting the presentation compiler on the
resulting classpath will recover that information from parsing the scala
signatures/pickles in the classfile bytecode.

Many thanks to Olaf for the advice.