### PR TITLE
bump Scalameta, Scalafix, sbt versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Add the `sbt-scalafix` sbt plugin, with the SemanticDB compiler plugin enabled (
 
 ```scala
 // project/plugins.sbt
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.24")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.4")
 ```
 
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import _root_.scalafix.sbt.BuildInfo._
 import sbt.librarymanagement.Configurations.CompilerPlugin
 
-def scalametaVersion = "4.5.4"
+def scalametaVersion = "4.6.0"
 
 inThisBuild(List(
   organization := "org.scala-lang",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.github.sbt"  % "sbt-ci-release" % "1.5.10")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"   % "0.9.34")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"   % "0.10.4")

--- a/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
+++ b/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala
@@ -21,7 +21,7 @@ import scalafix.internal.v1.LazyValue
 final class ExplicitNonNullaryApply(global: LazyValue[ScalafixGlobal])
     extends SemanticRule("fix.scala213.ExplicitNonNullaryApply")
 {
-  def this() = this(LazyValue.later(() => ScalafixGlobal.newCompiler(Nil, Nil, Map.empty)))
+  def this() = this(LazyValue.later(() => ScalafixGlobal.newCompiler(Nil, Nil, Map.empty).get))
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     try unsafeFix() catch {
@@ -124,7 +124,7 @@ final class ExplicitNonNullaryApply(global: LazyValue[ScalafixGlobal])
       )
     } else {
       Configured.ok(new ExplicitNonNullaryApply(LazyValue.later { () =>
-        ScalafixGlobal.newCompiler(config.scalacClasspath, config.scalacOptions, Map.empty)
+        ScalafixGlobal.newCompiler(config.scalacClasspath, config.scalacOptions, Map.empty).get
       }))
     }
   }


### PR DESCRIPTION
replaces a bunch of steward PRs — easier to land it all together as the Scalameta & Scalafix updates aren't independent

(and then the sbt one is just a bonus)

* Scalameta 4.6.0 (was 4.5.4)
* Scalafix 0.10.4 (was 0.9.24)
* sbt 1.7.3 (was 1.7.1)